### PR TITLE
fix

### DIFF
--- a/addons/cost_estimate/models/project_expense_line.py
+++ b/addons/cost_estimate/models/project_expense_line.py
@@ -29,10 +29,10 @@ class ProjectExpenseLine(models.Model):
     ('other', 'Chi phí khác')
 ], string="Loại chi phí", default=lambda self: self.env.context.get('default_type'), store=True)
     
-    percent = fields.Float(
-        string='Hệ số (%)',
-        default=0.0,
-        help="Tăng/Giảm theo % trên thành tiền gốc"
+    factor = fields.Float(
+        string='Hệ số',
+        default=1.0,
+        help="Hệ số nhân cho thành tiền gốc (ví dụ 1.08, 1.9 ...)"
     )
 
     @api.onchange('expense_id')
@@ -48,11 +48,11 @@ class ProjectExpenseLine(models.Model):
             self.price_unit = 0.0
             self.type = 'other'
 
-    @api.depends('price_unit', 'quantity', 'percent')
+    @api.depends('price_unit', 'quantity', 'factor')
     def _compute_price_total(self):
         for rec in self:
             base_amount = rec.price_unit * rec.quantity
-            rec.price_total = base_amount * (1 + (rec.percent or 0.0) / 100.0)
+            rec.price_total = base_amount * (rec.factor or 1.0)
 
     @api.model_create_multi
     def create(self, vals_list):

--- a/addons/cost_estimate/views/cost_estimate_views.xml
+++ b/addons/cost_estimate/views/cost_estimate_views.xml
@@ -145,16 +145,16 @@
                             <field name="labor_expense_line_ids" context="{'default_estimate_line_id': active_id, 'default_type': 'labor'}" mode="tree,form">
                                 <tree editable="bottom">
                                     <field name="expense_id" context="{'default_type': 'labor'}" string="Chi phí nhân công" domain="[('type', '=', 'labor')]" />
-                                    <field name="percent" string="Hệ số (%)"/>
+                                    <field name="factor" string="Hệ số"/>
                                     <field name="quantity"/>
                                     <field name="unit"/>
                                     <field name="price_unit"/>
-                                    <field name="price_total" readonly="1"/>
+                                    <field name="price_total" readonly="1" sum="Tổng"/>
                                 </tree>
                                 <form>
                                     <group>
                                         <field name="expense_id" context="{'default_type': 'labor'}" string="Chi phí nhân công" domain="[('type', '=', 'labor')]" />
-                                        <field name="percent" string="Hệ số (%)"/>
+                                        <field name="factor" string="Hệ số"/>
                                         <field name="quantity"/>
                                         <field name="unit"/>
                                         <field name="price_unit"/>
@@ -167,16 +167,16 @@
                             <field name="expense_line_ids" context="{'default_estimate_line_id': active_id, 'default_type': 'other'}" mode="tree,form">
                                 <tree editable="bottom">
                                     <field name="expense_id" context="{'default_type': 'other'}" domain="[('type', '=', 'other')]" string="Chi phí sản xuất chung"/>
-                                    <field name="percent" string="Hệ số (%)"/>
+                                    <field name="factor" string="Hệ số"/>
                                     <field name="quantity"/>
                                     <field name="unit"/>
                                     <field name="price_unit"/>
-                                    <field name="price_total" readonly="1"/>
+                                    <field name="price_total" readonly="1" sum="Tổng"/>
                                 </tree>
                                 <form>
                                     <group>
                                         <field name="expense_id" context="{'default_type': 'other'}" domain="[('type', '=', 'other')]" string="Chi phí sản xuất chung"/>
-                                        <field name="percent" string="Hệ số (%)"/>
+                                        <field name="factor" string="Hệ số"/>
                                         <field name="quantity"/>
                                         <field name="unit"/>
                                         <field name="price_unit"/>

--- a/addons/custom_account_payment_request/models/account_payment_request.py
+++ b/addons/custom_account_payment_request/models/account_payment_request.py
@@ -51,6 +51,10 @@ class AccountingPaymentRequest(models.Model):
         ('not yet', 'Chưa chi'),
         ('paid', 'Đã chi'),
     ], default='not yet')
+    document_date = fields.Date(
+    string="Ngày chứng từ",
+    default=fields.Date.context_today,
+)
     @api.model
     def create(self, vals):
         if vals.get('name', '/') == '/':

--- a/addons/custom_account_payment_request/views/account_payment_request_views.xml
+++ b/addons/custom_account_payment_request/views/account_payment_request_views.xml
@@ -45,6 +45,7 @@
                             <field name="total" widget="monetary" options="{'currency_field': 'currency_id'}" readonly="state != 'draft'"/>
                             <field name="payment_person" widget="many2one_avatar_user" readonly="1"/>
                             <field name="create_date" string="Ngày tạo" readonly="1"/>
+                            <field name="document_date" readonly="state != 'draft'"/>
                             <field name="note" readonly="state != 'draft'"/>
                             <field name="currency_id" invisible="1"/>
                         </group>

--- a/addons/project_material/models/product_material_line.py
+++ b/addons/project_material/models/product_material_line.py
@@ -17,10 +17,10 @@ class ProductMaterialLine(models.Model):
         store=True,
         digits=(16, 0)
     ) 
-    percent = fields.Float(
-        string='Phí (%)',
-        default=0.0,
-        help="Tăng/Giảm theo % trên thành tiền gốc"
+    factor = fields.Float(
+        string='Hệ số',
+        default=1.0,
+        help="Hệ số nhân cho thành tiền gốc (ví dụ 1.08, 1.9 ...)"
     )
     vendor_id = fields.Many2one(
         'res.partner',
@@ -38,11 +38,11 @@ class ProductMaterialLine(models.Model):
             self.price_unit = 0.0
             self.vendor_id = False
 
-    @api.depends('price_unit', 'quantity', 'percent')
+    @api.depends('quantity', 'factor','price_unit','price_total')
     def _compute_price_total(self):
         for rec in self:
             base_amount = rec.price_unit * rec.quantity
-            rec.price_total = base_amount * (1 + (rec.percent or 0.0) / 100.0)
+            rec.price_total = base_amount * (rec.factor or 1.0)
             
 
     

--- a/addons/project_material/views/material_views_line.xml
+++ b/addons/project_material/views/material_views_line.xml
@@ -5,11 +5,11 @@
         <field name="arch" type="xml">
             <tree editable="bottom">
                 <field name="material_id" required="1" width="30%"/>
-                <field name ="percent" string="Hệ số (%)"/>
+                <field name ="factor" string="Hệ số"/>
                 <field name="quantity" required="1" width="15%"/>
                 <field name="unit" widget="selection" options="{'no_create': True}" required="1" width="15%"/>
                 <field name="price_unit" required="1" width="20%"/>
-                <field name="price_total" readonly="1" width="20%"/>
+                <field name="price_total" readonly="1" width="20%" sum="Tổng"/>
                 <field name="vendor_id" placeholder="Nhà cung cấp" width="30%"/>
             </tree>
         </field>
@@ -22,7 +22,7 @@
             <form>
                 <group>
                     <field name="material_id" required="1"/>
-                    <field name ="percent" string="Hệ số (%)"/>
+                    <field name ="factor" string="Hệ số"/>
                     <field name="quantity" required="1"/>
                     <field name="unit" required="1"/>
                     <field name="price_unit" required="1"/>


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Added “Ngày chứng từ” field to Payment Request, editable in draft and read-only afterward.
  - List views for labor/other expense and material lines now show summed “Tổng” for totals.
- Refactor
  - Replaced percent-based fees with a multiplicative “Hệ số” on expense and material lines (default 1.0).
  - Updated price calculations to multiply by the factor for clearer, consistent totals.
  - Updated forms and lists to display “Hệ số” instead of percent.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->